### PR TITLE
fix: Add dotenv config to load environment variables

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,8 @@ import express from 'express'
 import cors from 'cors'
 import { connectDB } from './config/db.js';
 import foodRouter from './routes/foodRoute.js';
+import 'dotenv/config';
+
 
 
 // app config


### PR DESCRIPTION
 closes #12 Bug: Backend server fails to load environment variables 

The backend server was previously unable to load environment variables from the .env file. This caused the application to crash on startup because the MONGODB_URI was undefined, leading to a database connection failure.

This fix adds the necessary import statement to initialize the dotenv package at the very beginning of the application's lifecycle, ensuring all environment variables are loaded correctly before they are needed.

Changes Made
Added import 'dotenv/config'; to the top of the backend/server.js file.

This ensures that the server can now access the MONGODB_URI and successfully connect to the MongoDB Atlas database as intended.