### PR TITLE
fix: Adjust header max-width for large screens

### DIFF
--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -57,3 +57,8 @@
         padding: 2vw 4vw;
     }
 }
+@media (min-width:1080px){
+    .header-contents h2{
+        font-size: 40px;
+    }
+}


### PR DESCRIPTION
Closes #56

## 🛠️ Changes Made
- Adjusted `.header-contents h2` size to 40px
- Ensured content remains aligned within image background across all viewports

## 📸 Screenshot (Fixed View)
<img width="1198" height="497" alt="image" src="https://github.com/user-attachments/assets/6d4ebd8c-880d-45bb-9851-87b94d6febcb" />
