### PR TITLE
#60 Add persistent bottom Cart Summary bar 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
-
         "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
@@ -3456,6 +3456,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.26.2"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,10 @@ import AppDownload from "./components/AppDownlad/AppDownload";
 import LoginPopup from "./components/LoginPopup/LoginPopup";
 import ThemeContextProvider from "./components/context/ThemeContext";
 import FoodDetail from "./components/FoodDetail/FoodDetail";
+import CartSummaryBar from "./components/CartSummaryBar/CartSummaryBar";
+import ScrollToTop from './components/ScrollToTop';
+
+
 
 const App = () => {
   const [showLogin, setShowLogin] = useState(false);
@@ -17,6 +21,7 @@ const App = () => {
     <ThemeContextProvider>
       <>
         {showLogin ? <LoginPopup setShowLogin={setShowLogin} /> : <></>}
+         <ScrollToTop />
         <div className="app">
           <Navbar setShowLogin={setShowLogin} />
           <Routes>
@@ -25,6 +30,7 @@ const App = () => {
             <Route path="/order" element={<PlaceOrder />} />
             <Route path="/food/:id" element={<FoodDetail />}></Route>
           </Routes>
+           <CartSummaryBar />
           <AppDownload />
           <Footer />
         </div>

--- a/frontend/src/components/CartSummaryBar/CartSummaryBar.css
+++ b/frontend/src/components/CartSummaryBar/CartSummaryBar.css
@@ -1,0 +1,28 @@
+.cart-summary-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #FC4B32;
+  color: white;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 24px;
+  z-index: 1000;
+  font-weight: bold;
+}
+
+.view-cart-btn {
+  background-color: white;
+  color: #FC4B32;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.view-cart-btn:hover {
+  background-color: #ffe6e6;
+}

--- a/frontend/src/components/CartSummaryBar/CartSummaryBar.jsx
+++ b/frontend/src/components/CartSummaryBar/CartSummaryBar.jsx
@@ -1,0 +1,30 @@
+import React, { useContext } from 'react';
+import './CartSummaryBar.css';
+import { StoreContext } from '../context/StoreContext';
+import { useNavigate, useLocation } from 'react-router-dom'; //  import useLocation
+
+const CartSummaryBar = () => {
+  const { cartItems, getTotalCartAmount } = useContext(StoreContext);
+  const navigate = useNavigate();
+  const location = useLocation(); 
+
+  const totalItems = Object.values(cartItems).reduce((sum, item) => sum + item, 0);
+  const totalAmount = getTotalCartAmount();
+
+  // Don't show if cart is empty or if you're already on the cart page
+  if (totalItems === 0 || location.pathname === '/cart') return null;
+
+  return (
+    <div className="cart-summary-bar">
+      <div className="cart-summary-info">
+        🛒 {totalItems} item{totalItems > 1 ? 's' : ''} | 💵 ₹{totalAmount}
+      </div>
+      <button className="view-cart-btn" onClick={() => navigate('/cart')}>
+        VIEW CART
+      </button>
+    </div>
+  );
+};
+
+export default CartSummaryBar;
+

--- a/frontend/src/components/ScrollToTop.jsx
+++ b/frontend/src/components/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
I solved the issue#60

1. Cart Summary Bar Appears After Adding Items:

 -🛒 Shows item count and total price.
-📍 Fixed at the bottom of the screen. 

<img width="1846" height="865" alt="Screenshot 2025-07-24 164702" src="https://github.com/user-attachments/assets/132fd010-5f62-4e5e-afa5-5d336cbbfc5e" />


3. Clicking "VIEW CART" Takes You to Cart Page (Scrolls to Top)
- 🚀 Smooth navigation
- 🧹 Automatically scrolls to the top of /cart page.
- 🚫 Cart bar hidden on /cart.


4. Cart Summary Bar is Hidden When Cart is Empty 
<img width="1868" height="825" alt="Screenshot 2025-07-24 164553" src="https://github.com/user-attachments/assets/93b9cebd-ab51-46c2-8cb8-89becc04e6cb" />
