### PR TITLE
fix: instantly update wishlist UI using custom event trigger

### DIFF
--- a/frontend/src/components/FoodItem/FoodItem.jsx
+++ b/frontend/src/components/FoodItem/FoodItem.jsx
@@ -28,6 +28,7 @@ const FoodItem = ({ id, name, price, description, image }) => {
     }
 
     localStorage.setItem("wishlist", JSON.stringify(updated));
+     window.dispatchEvent(new Event("wishlistUpdated"));
   };
 
   const handleClick = () => {

--- a/frontend/src/pages/wishlist/wishlist.jsx
+++ b/frontend/src/pages/wishlist/wishlist.jsx
@@ -8,9 +8,20 @@ const Wishlist = () => {
   const [wishlistedItems, setWishlistedItems] = useState([]);
 
   useEffect(() => {
+    const updateWishlist = () => {
     const wishlistIds = JSON.parse(localStorage.getItem('wishlist')) || [];
     const filtered = food_list.filter(food => wishlistIds.includes(food._id));
     setWishlistedItems(filtered);
+  };
+     updateWishlist(); // Load initially
+
+  // Listen for custom wishlist update event
+  window.addEventListener("wishlistUpdated", updateWishlist);
+
+  // Cleanup when component unmounts
+  return () => {
+    window.removeEventListener("wishlistUpdated", updateWishlist);
+  };
   }, [food_list]);
 
   return (


### PR DESCRIPTION
## 📌 Pull Request Summary

- Implemented a `wishlistUpdated` custom event that gets dispatched whenever the wishlist is modified.
- In the `Wishlist` component, added an event listener for `wishlistUpdated` to re-fetch and update the wishlisted items in real-time.
- This ensures immediate UI feedback when items are added or removed from the wishlist, without requiring a page refresh.



## 🛠️ Type of Change

Please select options that are relevant to your pull request

- [X] 🐛 Bug fix  
- [ ] ✨ New feature  
- [ ] 🧹 Code refactor  
- [ ] 🧪 Tests added/updated  
- [ ] 📄 Documentation update  
- [ ] 🚀 Performance improvement  
- [ ] 🔧 Other (please describe):

## 🔗 Related Issue

Closes #170


## ✅ Checklist

Please confirm the following before submitting:

- [x] I have **tested** my changes locally
- [x] I have run `npm run dev` or similar to check code style
- [x] I have updated documentation (if necessary)
- [x] My code follows the project’s coding conventions
- [x] I have merged the latest `main` or `dev` branch
- [x] I have performed a **self-review** of my own code.
- [x] My changes **generate** no new warnings or errors.
- [x] I have **commented** my code, especially in hard-to-understand areas
- [x] I have **linked the related issue**



## 📸 Screenshots (if applicable)

https://github.com/user-attachments/assets/a51c4449-c3ce-47ed-9f6a-3c7a16fc767b




---



