### PR TITLE
fix: prevent icon and input text overlap in search bar 

### DIFF
--- a/frontend/src/components/SearchBar/SearchBar.css
+++ b/frontend/src/components/SearchBar/SearchBar.css
@@ -29,14 +29,19 @@
   align-items: center;
   flex: 1;
   position: relative;
-  padding: 0 12px;
+  padding: 0;
 }
 
 .search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
   color: var(--text-secondary, #64748b);
-  margin-right: 12px;
-  flex-shrink: 0;
+  pointer-events: none;
+  z-index: 1;
 }
+
 
 .search-input {
   border: none;
@@ -45,7 +50,7 @@
   font-size: 16px;
   color: var(--text-color, #2d3748);
   width: 100%;
-  padding: 12px 0;
+  padding: 12px 0 12px 36px;
   font-family: inherit;
 }
 


### PR DESCRIPTION
## 📌 Pull Request Summary 
Fixed a bug where the search bar icon was overlapping with text .


## 🛠️ Type of Change

Please select options that are relevant to your pull request

- [X] 🐛 Bug fix  



## ✅ Checklist

Please confirm the following before submitting:

- [X] I have **tested** my changes locally
- [X] I have run `npm run dev` or similar to check code style
- [X] My code follows the project’s coding convention
-  [X] I have **linked the related issue**



## 📸 Screenshots (if applicable)
BEFORE
<img width="729" height="93" alt="Screenshot 2025-07-30 210348" src="https://github.com/user-attachments/assets/2f47b596-f483-415e-9a9c-c402ed500f59" />
AFTER
<img width="859" height="193" alt="Screenshot 2025-07-31 101045" src="https://github.com/user-attachments/assets/c908734c-4bc7-4b07-93fd-337a0e3a6cac" />

Fixes #188 

