### PR TITLE
Fix: Search icon overlapping placeholder text (#205)

### DIFF
--- a/frontend/src/components/SearchBar/SearchBar.css
+++ b/frontend/src/components/SearchBar/SearchBar.css
@@ -203,7 +203,7 @@
   
   .search-input {
     font-size: 16px; /* Prevents zoom on iOS */
-    padding: 10px 0;
+    padding: 10px 0 10px 36px;
   }
   
   .search-button {


### PR DESCRIPTION
## 📌 Pull Request Summary

`Fixed a UI bug where the search icon was overlapping with the placeholder text inside the search input on smaller screen widths. The issue was caused by insufficient left padding on the input field and missing relative positioning on the wrapper..`


## 🛠️ Type of Change

Please select options that are relevant to your pull request

- [x] 🐛 Bug fix  
- [ ] ✨ New feature  
- [ ] 🧹 Code refactor  
- [ ] 🧪 Tests added/updated  
- [ ] 📄 Documentation update  
- [ ] 🚀 Performance improvement  
- [ ] 🔧 Other (please describe):

## 🔗 Related Issue

Closes #205



## ✅ Checklist

Please confirm the following before submitting:

- [x] I have **tested** my changes locally
- [x] I have run `npm run dev` or similar to check code style
- [ ] I have updated documentation (if necessary)
- [x] My code follows the project’s coding conventions
- [x] I have merged the latest `main` or `dev` branch
- [x] I have performed a **self-review** of my own code.
- [x] My changes **generate** no new warnings or errors.
- [x]  I have **commented** my code, especially in hard-to-understand areas
-  [x] I have **linked the related issue**



## 📸 Screenshots (if applicable)
<img width="976" height="709" alt="image" src="https://github.com/user-attachments/assets/f19bfbb8-8777-4528-a690-9e60b5a32384" />

