### PR TITLE
Fix: Add cookie-parser dependency and harden protect middleware

### DIFF
--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -3,7 +3,7 @@ import User from '../models/userModel.js';
 
 export const protect = async (req, res, next) => {
   try {
-    // Get token from cookie instead of Authorization header
+    // Get token from cookies
     const token = req.cookies?.token;
     if (!token) {
       return res.status(401).json({ message: 'Not authorized, no token found' });
@@ -12,15 +12,23 @@ export const protect = async (req, res, next) => {
     // Verify token
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
-    // Attach user to request object
-    req.user = await User.findById(decoded.id).select('-password');
+    if (!decoded?.id) {
+      return res.status(401).json({ message: 'Invalid token payload' });
+    }
 
-    if (!req.user) {
+    // Find the user and exclude password field
+    const user = await User.findById(decoded.id).select('-password');
+    if (!user) {
       return res.status(401).json({ message: 'Not authorized, user not found' });
     }
 
+    req.user = user; // attach to request
     next();
   } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      return res.status(401).json({ message: 'Token expired' });
+    }
     return res.status(401).json({ message: 'Not authorized, token invalid' });
   }
 };
+


### PR DESCRIPTION
## 📌 Pull Request Summary

## What I did
- Added `cookie-parser` middleware in server setup so `req.cookies` works properly.
- Updated `protect` middleware to:
    - Check for missing/invalid JWT payload (`decoded.id`).
    - Differentiate between expired and invalid tokens.
    - Prevent runtime errors when cookies or payload are missing.

## Why
Without `cookie-parser`, `req.cookies` is undefined, causing token retrieval to fail in `protect` middleware.
This fix ensures proper cookie parsing and improves token validation, making authentication more reliable.

## Testing done
- Without token → returns 401 "Not authorized, no token found"
- With invalid token → returns 401 "Not authorized, token invalid"
- With expired token → returns 401 "Token expired"
- With valid token and an existing user → protected route access works as expected



## 🛠️ Type of Change

🐛 Bug fix (non‑breaking change which fixes an issue)

✨ New feature

💥 Breaking change

📄 Documentation update


## 🔗 Related Issue

Fixes #354 



## ✅ Checklist


    My code follows the style guidelines of this project

    I have performed a self‑review of my own code

    I have commented my code where necessary

    I have tested the changes locally and verified all scenarios

    I have not introduced unnecessary new dependencies




## 📸 Screenshots (if applicable)


* Add before/after screenshots or UI changes.



---
## 🧠 Additional Notes

- Anything else you want the reviewer to know.


