### PR TITLE
Fix: Updated visibility of left side text in contact page in dark mode

### DIFF
--- a/frontend/src/components/ContactForm/ContactForm.css
+++ b/frontend/src/components/ContactForm/ContactForm.css
@@ -47,7 +47,7 @@ html, body {
   color: #e65100;
 }
 
-.description {
+.contact-container .description {
   font-size: 1.1rem;
   margin-bottom: 2rem;
   line-height: 1.6;


### PR DESCRIPTION
## 📌 Pull Request Summary

Fix: Corrected CSS class/selector names for the Contact page dark-mode styles. The left-panel description text wasn’t visible because the rules targeted the wrong classes; updated selectors and verified contrast/readability.


## 🛠️ Type of Change

Please select options that are relevant to your pull request

- [x] 🐛 Bug fix  
- [ ] ✨ New feature  
- [ ] 🧹 Code refactor  
- [ ] 🧪 Tests added/updated  
- [ ] 📄 Documentation update  
- [ ] 🚀 Performance improvement  
- [ ] 🔧 Other (please describe):

## 🔗 Related Issue

Closes #401 



## ✅ Checklist

Please confirm the following before submitting:

- [x] I have **tested** my changes locally
- [x] I have run `npm run dev` or similar to check code style
- [ ] I have updated documentation (if necessary)
- [x] My code follows the project’s coding conventions
- [x] I have merged the latest `main` or `dev` branch
- [x] I have performed a **self-review** of my own code.
- [x] My changes **generate** no new warnings or errors.
- [ ] I have **commented** my code, especially in hard-to-understand areas
-  [x] I have **linked the related issue**



## 📸 Screenshots (if applicable)
Before:
<img width="1920" height="1080" alt="Screenshot (1011)" src="https://github.com/user-attachments/assets/290c7474-ea9b-4804-8a58-251315c698c6" />

After:
<img width="1896" height="908" alt="Screenshot 2025-08-16 110536" src="https://github.com/user-attachments/assets/6c49aa23-a96d-444b-b8ff-754e5025b987" />

