### PR TITLE
feat(auth): Add password strength checker to signup form

### DIFF
--- a/frontend/src/components/LoginPopup/LoginPopup.css
+++ b/frontend/src/components/LoginPopup/LoginPopup.css
@@ -121,3 +121,26 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.password-strength-checker p {
+  font-size: 0.9em;
+  margin: 5px 0;
+  display: flex;
+  align-items: center;
+}
+
+.password-strength-checker .valid {
+  color: green;
+}
+
+.password-strength-checker .invalid {
+  color: red;
+}
+
+.password-checker-box {
+  background-color: #f7f7f7; /* Light gray background */
+  border: 1px solid #ddd;    /* Light gray border */
+  border-radius: 8px;        /* Rounded corners */
+  padding: 10px;             /* Spacing inside the box */
+  margin-top: 3px;          /* Space between input and box */
+}

--- a/frontend/src/components/LoginPopup/LoginPopup.jsx
+++ b/frontend/src/components/LoginPopup/LoginPopup.jsx
@@ -17,6 +17,17 @@ const LoginPopup = ({ setShowLogin }) => {
   const [confirmPassword, setConfirmPassword] = useState("");
   const navigate=useNavigate();
 
+  const [password, setPassword] = useState('');
+  const [passwordStrength, setPasswordStrength] = useState({
+    length: false,
+    uppercase: false,
+    lowercase: false,
+    number: false,
+    special: false,
+  });
+
+  const [showPasswordChecker, setShowPasswordChecker] = useState(false);
+
   const popupRef = useRef();
   const otpRefs = useRef([]);
 
@@ -64,6 +75,27 @@ const LoginPopup = ({ setShowLogin }) => {
     }
   };
 
+  useEffect(() => {
+    if (password) {
+      const newStrength = {
+        length: password.length >= 8,
+        uppercase: /[A-Z]/.test(password),
+        lowercase: /[a-z]/.test(password),
+        number: /[0-9]/.test(password),
+        special: /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password),
+      };
+      setPasswordStrength(newStrength);
+    } else {
+      setPasswordStrength({
+        length: false,
+        uppercase: false,
+        lowercase: false,
+        number: false,
+        special: false,
+      });
+    }
+  }, [password]);
+
   const handleSendOTP = (e) => {
     e.preventDefault();
     if (!email) return toast.error("Enter email");
@@ -97,14 +129,14 @@ const LoginPopup = ({ setShowLogin }) => {
     const password = formData.get("password");
 
     if (!email || !password || (currState === "Sign Up" && !name)) {
-      return toast.error("Please fill all fields");
-    }
+        return toast.error("Please fill all fields");
+      }
 
     const endpoint =
       currState === "Sign Up" ? "/api/auth/register" : "/api/auth/login";
 
     try {
-      const { data } = await apiRequest.post(endpoint, { name, email, password });
+        const { data } = await apiRequest.post(endpoint, { name, email, password });
 
       toast.success(`${currState} successful!`);
 
@@ -140,7 +172,54 @@ const LoginPopup = ({ setShowLogin }) => {
           {!forgotFlow && (
             <>
               <input type="email" name="email" placeholder="Your Email" required />
-              <input type="password" name="password" placeholder="Your Password" required />
+              {currState === "Sign Up" && (
+                <input
+                  type="password"
+                  name="password"
+                  placeholder="Your Password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  onFocus={() => setShowPasswordChecker(true)}
+                  required
+                />
+              )}
+              {currState === "Sign Up" && showPasswordChecker && (
+                <div className="password-checker-box">
+                  <div className="password-strength-checker">
+                    <p className={passwordStrength.length ? 'valid' : 'invalid'}>
+                      {passwordStrength.length ? '✔️' : '❌'} At least 8 characters long
+                    </p>
+                    <p className={passwordStrength.uppercase ? 'valid' : 'invalid'}>
+                      {passwordStrength.uppercase ? '✔️' : '❌'} Contains at least one uppercase letter
+                    </p>
+                    <p className={passwordStrength.lowercase ? 'valid' : 'invalid'}>
+                      {passwordStrength.lowercase ? '✔️' : '❌'} Contains at least one lowercase letter
+                    </p>
+                    <p className={passwordStrength.number ? 'valid' : 'invalid'}>
+                      {passwordStrength.number ? '✔️' : '❌'} Contains at least one number
+                    </p>
+                    <p className={passwordStrength.special ? 'valid' : 'invalid'}>
+                      {passwordStrength.special ? '✔️' : '❌'} Contains at least one special character
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {currState === "Sign Up" && (
+                <div className="login-popup-condition">
+                  <input type="checkbox" required />
+                  <p>By continuing, I agree to the terms of use & privacy policy.</p>
+                </div>
+              )}
+
+              {currState === "Login" && (
+                <input
+                  type="password"
+                  name="password"
+                  placeholder="Your Password"
+                  required
+                />
+              )}
               <button type="submit">{currState === 'Sign Up' ? "Create Account" : "Login"}</button>
               {currState === "Login" && (
                 <p className="forgot-password-link" onClick={() => {
@@ -215,13 +294,6 @@ const LoginPopup = ({ setShowLogin }) => {
             </>
           )}
         </div>
-
-        {!forgotFlow && (
-          <div className="login-popup-condition">
-            <input type="checkbox" required />
-            <p>By continuing, I agree to the terms of use & privacy policy.</p>
-          </div>
-        )}
 
         {!forgotFlow && (
           currState === "Login" ? (


### PR DESCRIPTION
# 📌 Pull Request Summary  
This PR adds a **password strength checker** to the "Sign Up" form and restructures the form's layout for improved user experience.  

---

## 🛠️ Type of Change  
- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [x] 🧹 Code refactor  
- [ ] 🧪 Tests added/updated  
- [ ] 📄 Documentation update  
- [ ] 🚀 Performance improvement  
- [ ] 🔧 Other (please describe):  

---

## 🔗 Related Issue  
Closes #390 

---

## ✅ Checklist  
- [x] I have tested my changes locally  
- [x] I have run `npm run dev` or similar to check code style  
- [ ] I have updated documentation (if necessary)  
- [x] My code follows the project’s coding conventions  
- [ ] I have merged the latest main or dev branch  
- [x] I have performed a self-review of my own code  
- [x] My changes generate no new warnings or errors  
- [x] I have commented my code, especially in hard-to-understand areas  
- [x] I have linked the related issue  

---

## 📸 Screenshots (if applicable)  
**Before:**  
<img width="1919" height="946" alt="image" src="https://github.com/user-attachments/assets/da4dbabc-5f9c-4e2f-893d-384831a913a3" />

**After:**  
 
<img width="1906" height="965" alt="Screenshot 2025-08-16 120350" src="https://github.com/user-attachments/assets/d6c409c5-0a64-4e9c-8620-f35b4378401f" />

<img width="1919" height="1003" alt="Screenshot 2025-08-16 120403" src="https://github.com/user-attachments/assets/834c11e2-f313-431d-90a8-2904dab8a0ee" />

---

## 🧠 Additional Notes
  
### ✨ New Feature: Password Strength Checker  
- Provides **real-time password strength feedback**.  
- Appears dynamically when the password input field is focused.  
- Uses a `useEffect` hook and state variables to validate:  
  - Password length  
  - Character types  
  - Special characters  

---

### 🎨 UI/UX Improvements  
- **Form Layout:** Improved for better user flow and aesthetics.  
- **Checkbox Relocation:** The "By continuing" checkbox was moved directly above the "Create Account" button for a more intuitive journey.  
- **Visual Design:** Password strength requirements are displayed inside a clean, styled box, reducing visual clutter and giving a more professional look.
