### PR TITLE
Fix unintended form submissions in LoginPopup

### DIFF
--- a/frontend/src/components/LoginPopup/LoginPopup.jsx
+++ b/frontend/src/components/LoginPopup/LoginPopup.jsx
@@ -254,7 +254,7 @@ const LoginPopup = ({ setShowLogin }) => {
                 onChange={(e) => setEmail(e.target.value)}
                 required
               />
-              <button onClick={handleSendOTP}>Send OTP</button>
+              <button type="button" onClick={handleSendOTP}>Send OTP</button>
             </>
           )}
 
@@ -272,7 +272,7 @@ const LoginPopup = ({ setShowLogin }) => {
                   />
                 ))}
               </div>
-              <button onClick={handleVerifyOTP}>Verify OTP</button>
+              <button type="button" onClick={handleVerifyOTP}>Verify OTP</button>
               <button
                 type="button"
                 disabled={timer > 0}
@@ -303,7 +303,7 @@ const LoginPopup = ({ setShowLogin }) => {
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 required
               />
-              <button onClick={handleResetPassword}>Reset Password</button>
+              <button type="button" onClick={handleResetPassword}>Reset Password</button>
             </>
           )}
         </div>


### PR DESCRIPTION
Added type="button" to non-submit buttons (Send OTP, Verify OTP, Resend OTP, Reset Password) to prevent accidental form submissions.

Before

Non-submit buttons triggered handleSubmit in addition to their own handlers.

After

Only Login / Sign Up submits the form.

Other buttons run only their respective handlers.