### PR TITLE
Add related products section to FoodDetail component

### DIFF
--- a/frontend/src/components/FoodDetail/FoodDetail.css
+++ b/frontend/src/components/FoodDetail/FoodDetail.css
@@ -182,3 +182,70 @@
 [data-theme="dark"] .view-btn:hover {
   background-color: var(--hover-red);
 }
+
+/* Related Products Section */
+.related-products-section {
+  margin-top: 80px;
+  padding: 40px 0;
+  border-top: 1px solid #e0e0e0;
+}
+
+.related-products-title {
+  font-size: 36px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 12px;
+  color: #1c1c1c;
+}
+
+.related-products-subtitle {
+  font-size: 16px;
+  text-align: center;
+  color: #666;
+  margin-bottom: 40px;
+}
+
+.related-products-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 30px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* Dark theme support for related products */
+[data-theme="dark"] .related-products-section {
+  border-top-color: #333;
+}
+
+[data-theme="dark"] .related-products-title {
+  color: var(--text-color-dark);
+}
+
+[data-theme="dark"] .related-products-subtitle {
+  color: #aaa;
+}
+
+/* Responsive design for related products */
+@media (max-width: 768px) {
+  .related-products-section {
+    margin-top: 60px;
+    padding: 30px 0;
+  }
+  
+  .related-products-title {
+    font-size: 28px;
+  }
+  
+  .related-products-grid {
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+  }
+}
+
+@media (max-width: 480px) {
+  .related-products-grid {
+    grid-template-columns: 1fr;
+    gap: 15px;
+  }
+}

--- a/frontend/src/components/FoodDetail/FoodDetail.jsx
+++ b/frontend/src/components/FoodDetail/FoodDetail.jsx
@@ -4,6 +4,7 @@ import { FaDollarSign, FaListUl, FaStar, FaShoppingCart } from "react-icons/fa";
 import { StoreContext } from "../context/StoreContext";
 import { useReactToPrint } from "react-to-print";
 import html2pdf from "html2pdf.js";
+import FoodItem from "../FoodItem/FoodItem";
 import "./FoodDetail.css";
 import "./print.css"; 
 
@@ -65,6 +66,11 @@ const FoodDetail = () => {
   if (!foodItem) {
     return <div className="food-detail">No food item found.</div>;
   }
+
+  // Get related products from the same category, excluding the current item
+  const relatedProducts = food_list
+    .filter(item => item.category === foodItem.category && item._id !== foodItem._id)
+    .slice(0, 5); // Limit to 5 related products
 
   return (
     <div className="food-detail-wrapper">
@@ -132,6 +138,28 @@ const FoodDetail = () => {
           </div>
         </div>
       </PrintableSection>
+
+      {/* Related Products Section */}
+      {relatedProducts.length > 0 && (
+        <div className="related-products-section">
+          <h2 className="related-products-title">Related Products</h2>
+          <p className="related-products-subtitle">
+            Other {foodItem.category.toLowerCase()} items you might like
+          </p>
+          <div className="related-products-grid">
+            {relatedProducts.map((item) => (
+              <FoodItem
+                key={item._id}
+                id={item._id}
+                name={item.name}
+                description={item.description}
+                price={item.price}
+                image={item.image}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 📌 Pull Request Summary

- When viewing a product detail page, show a **"Related Products"** section with items from the same category.  
- Example:  
  - If the user is viewing a **Cake**, suggest other cakess.  
  - If the user is viewing a **Sandwich**, suggest other sandwiches. 

## 🛠️ Type of Change

Please select options that are relevant to your pull request
- [x] ✨ New feature  

## 🔗 Related Issue

Closes #508 



## ✅ Checklist

Please confirm the following before submitting:

- [x] I have **tested** my changes locally
- [x] I have run `npm run dev` or similar to check code style
- [x] My code follows the project’s coding conventions
- [x] I have merged the latest `main` or `dev` branch
- [x] I have performed a **self-review** of my own code.
- [x] My changes **generate** no new warnings or errors.
- [x] I have **commented** my code, especially in hard-to-understand areas
-  [x] I have **linked the related issue**


<img width="1918" height="932" alt="image" src="https://github.com/user-attachments/assets/dba5bf87-8847-47e4-a79f-d382006be3c5" />
