### PR TITLE
added dark mode for restaurant card

### DIFF
--- a/frontend/src/pages/Restaurants/Restaurants.css
+++ b/frontend/src/pages/Restaurants/Restaurants.css
@@ -59,7 +59,11 @@
 .restaurant-card:hover {
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
   transform: translateY(-5px);
-  background-color: #f9f6f2;
+  background-color: #fff;
+}
+
+[data-theme="dark"] .restaurant-card:hover {
+  background-color: #222;
   color: #d35400;
 }
 


### PR DESCRIPTION
changed the background color of the restaurant card in the /restaurants page.
Now the restaurant card has a specific background color for dark mode version.

closes: #532 

before: 
<img width="1021" height="642" alt="image" src="https://github.com/user-attachments/assets/f1e784c0-e1fe-4b25-8543-ab4c2ecdb9c5" />

after:
<img width="927" height="635" alt="image" src="https://github.com/user-attachments/assets/ab2d868e-772a-40fc-af4f-cce1d59ee564" />
