### PR TITLE
Add Contributors Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,12 +359,29 @@ We welcome contributions to the Foodie project! If you find this project helpful
 5. Submit a pull request
 
 ---
+
+## Contributor
+
+A heartfelt thank you to all the contributors who have dedicated their time and effort to make this project a success.  
+Your contributions—whether it’s code, design, testing, or documentation—are truly appreciated! 🚀
+
+#### Thanks to all the wonderful contributors 💖
+
+<a href="https://github.com/Abhishek2634/Foodie/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Abhishek2634/Foodie" />
+</a>
+
+#### See full list of contribution from contributor [Contributor Graph](https://github.com/Abhishek2634/Foodie/graphs/contributors)
+
+---
+
 ## 📄 License
 This project is licensed under the [MIT License](./LICENSE)
 
 - [LinkedIn](https://www.linkedin.com/in/abhishekfarswal/?originalSubdomain=in)  
 - [Twitter](https://x.com/Abhishek899620)  
 - [Instagram](https://www.instagram.com/abhishekfarswal/)
+  
 ---
 ## Contact 📝
 If you have any questions, feedback, or want to collaborate, feel free to reach out to the project maintainer:


### PR DESCRIPTION
Description
This PR adds a Contributors section to the README.md to recognize and showcase all contributors, making the repository more welcoming for new contributors.

Current Problem
The README.md currently lacks a Contributors section to recognize contributors and guide new ones.

Proposed Solution
Add a Contributors section at the end of README.md
Include an auto-generated contributor badge via [contrib.rocks](https://contrib.rocks/)
Update Table of Contents to include this new section
Keep all existing content intact and improve formatting where necessary

Benefits
Recognizes contributors and shows appreciation
Makes the repository more welcoming for new contributors
Improves documentation readability and structure

Close issue #748 