### PR TITLE
Highlight active FAQ question with CSS

### DIFF
--- a/frontend/src/components/FAQ/FAQ.css
+++ b/frontend/src/components/FAQ/FAQ.css
@@ -286,3 +286,16 @@
 .faq-answer::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 107, 107, 0.5);
 } 
+/* Highlight the active FAQ item */
+.faq-item.active {
+  background-color: rgba(255, 107, 107, 0.1); /* subtle pink highlight */
+  border-left: 4px solid #ff6b6b;             /* accent color on left */
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 12px rgba(255, 107, 107, 0.1); /* subtle elevation */
+}
+
+/* Optional: rotate chevron for active FAQ */
+.faq-item.active .faq-toggle {
+  transform: rotate(180deg);
+  transition: transform 0.3s ease;
+}

--- a/frontend/src/components/FAQ/FAQ.jsx
+++ b/frontend/src/components/FAQ/FAQ.jsx
@@ -8,46 +8,14 @@ const FAQ = () => {
 
   // Dummy FAQ data
   const faqData = [
-    {
-      id: 1,
-      question: "How do I place an order?",
-      answer: "Browse our menu, add items to cart, and proceed to checkout. We accept cards, digital wallets, and cash on delivery."
-    },
-    {
-      id: 2,
-      question: "What are your delivery times?",
-      answer: "Standard delivery is 30-45 minutes. Track your order in real-time through our app."
-    },
-    {
-      id: 3,
-      question: "Do you offer vegetarian options?",
-      answer: "Yes, we have extensive vegetarian and vegan options. Filter by dietary preferences in our menu."
-    },
-    {
-      id: 4,
-      question: "Can I cancel my order?",
-      answer: "Orders can be cancelled within 5 minutes. Contact support for later cancellations."
-    },
-    {
-      id: 5,
-      question: "What payment methods do you accept?",
-      answer: "We accept all major credit cards, debit cards, digital wallets (PayPal, Apple Pay, Google Pay), and cash on delivery."
-    },
-    {
-      id: 6,
-      question: "Is there a minimum order amount?",
-      answer: "Minimum $10 for delivery orders. No minimum for pickup orders."
-    },
-    {
-      id: 7,
-      question: "Do you offer loyalty rewards?",
-      answer: "Join our loyalty program to earn points on every order. Redeem for discounts on future orders."
-    },
-    {
-      id: 8,
-      question: "How do I report an issue?",
-      answer: "Contact our customer support immediately through the app, website, or support line."
-    }
+    { id: 1, question: "How do I place an order?", answer: "Browse our menu, add items to cart, and proceed to checkout. We accept cards, digital wallets, and cash on delivery." },
+    { id: 2, question: "What are your delivery times?", answer: "Standard delivery is 30-45 minutes. Track your order in real-time through our app." },
+    { id: 3, question: "Do you offer vegetarian options?", answer: "Yes, we have extensive vegetarian and vegan options. Filter by dietary preferences in our menu." },
+    { id: 4, question: "Can I cancel my order?", answer: "Orders can be cancelled within 5 minutes. Contact support for later cancellations." },
+    { id: 5, question: "What payment methods do you accept?", answer: "We accept all major credit cards, debit cards, digital wallets (PayPal, Apple Pay, Google Pay), and cash on delivery." },
+    { id: 6, question: "Is there a minimum order amount?", answer: "Minimum $10 for delivery orders. No minimum for pickup orders." },
+    { id: 7, question: "Do you offer loyalty rewards?", answer: "Join our loyalty program to earn points on every order. Redeem for discounts on future orders." },
+    { id: 8, question: "How do I report an issue?", answer: "Contact our customer support immediately through the app, website, or support line." }
   ];
 
   // Filter FAQ items based on search term
@@ -86,7 +54,10 @@ const FAQ = () => {
         <div className="faq-list">
           {filteredFAQ.length > 0 ? (
             filteredFAQ.map((item) => (
-              <div key={item.id} className="faq-item">
+              <div 
+                key={item.id} 
+                className={`faq-item ${expandedId === item.id ? 'active' : ''}`} // ✅ Added active class
+              >
                 <div 
                   className="faq-question"
                   onClick={() => toggleItem(item.id)}


### PR DESCRIPTION
📌 Pull Request Summary

Added highlighting for the active FAQ question so that users can clearly see which question is expanded. The highlight includes background color, left border, and subtle shadow, along with a rotating chevron.

🛠️ Type of Change

 🐛 Bug fix

 ✨ New feature

 🧹 Code refactor

 🧪 Tests added/updated

 📄 Documentation update

 🚀 Performance improvement

 🔧 Other (please describe):

🔗 Related Issue

Closes #754

✅ Checklist

 I have tested my changes locally

 I have run npm run dev or similar to check code style

 I have updated documentation (if necessary)

 My code follows the project’s coding conventions

 I have merged the latest main or dev branch

 I have performed a self-review of my own code

 My changes generate no new warnings or errors

 I have commented my code, especially in hard-to-understand areas

 I have linked the related issue

📸 Screenshots (if applicable)

Before: No highlight on expanded FAQ
After: Active FAQ question highlighted with background, left border, shadow, and rotated chevron.

🧠 Additional Notes

Works for both light and dark mode

Fully responsive

No impact on other FAQ functionalities


