### PR TITLE
Fixed item number issue on cart in navbar 

### DIFF
--- a/frontend/src/components/Navbar/Navbar.css
+++ b/frontend/src/components/Navbar/Navbar.css
@@ -184,7 +184,7 @@ body {
 .cart-badge {
   position: absolute;
   top: 2px;
-  right: 2px;
+  right: 13px;
   background: #fc4b32;
   color: #fff;
   font-size: 12px;

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -207,7 +207,7 @@ const Navbar = ({ setShowLogin, setIsLoggedIn }) => {
             <Link to="/cart" className="icon-button" aria-label="Go to cart">
               <ShoppingCart size={18} />
               {totalCartItems > 0 && (
-                <div className="cart-badge">{totalCartItems}</div>
+                <div className="cart-badge" >{totalCartItems}</div>
               )}
             </Link>
           </div>


### PR DESCRIPTION
fixes #753 

- item number is not visible on the cart properly . Earlier it was overlapping inside sign in button 

<img width="668" height="512" alt="image" src="https://github.com/user-attachments/assets/e3d04f07-017d-4725-baf2-9c238db581fb" />
