### PR TITLE
Dropdown toggle on Privacy page

### DIFF
--- a/frontend/src/components/Privacy/privacy.css
+++ b/frontend/src/components/Privacy/privacy.css
@@ -60,11 +60,11 @@
 
 /* Privacy sections */
 .privacy-section {
-  margin-bottom: 30px;
-  padding: 20px;
+  margin-bottom: 15px;
   border-radius: 10px;
   background: rgba(239, 174, 78, 0.05);
   border-left: 4px solid #efae4e;
+  overflow: hidden;
 }
 
 .privacy-container.dark .privacy-section {
@@ -72,20 +72,88 @@
   border-left-color: #ff8c00;
 }
 
-.privacy-section h2 {
+/* Section header */
+.privacy-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  margin: 0;
+}
+
+.privacy-section-header h2 {
   font-size: 1.5rem;
   font-weight: 600;
-  margin-bottom: 15px;
+  margin: 0;
   color: #efae4e;
 }
 
-.privacy-container.dark .privacy-section h2 {
+.privacy-container.dark .privacy-section-header h2 {
   color: #ff8c00;
 }
 
-.privacy-section p {
+/* Dropdown toggle button */
+.dropdown-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  transition: background-color 0.3s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dropdown-toggle:hover {
+  background: rgba(239, 174, 78, 0.1);
+}
+
+.privacy-container.dark .dropdown-toggle:hover {
+  background: rgba(255, 140, 0, 0.15);
+}
+
+.dropdown-toggle:focus {
+  outline: 2px solid #efae4e;
+  outline-offset: 2px;
+}
+
+.privacy-container.dark .dropdown-toggle:focus {
+  outline: 2px solid #ff8c00;
+}
+
+/* Dropdown icon */
+.dropdown-icon {
+  font-size: 0.8rem;
+  transition: transform 0.3s ease;
+  color: #efae4e;
+  display: inline-block;
+}
+
+.dropdown-icon.open {
+  transform: rotate(180deg);
+}
+
+.privacy-container.dark .dropdown-icon {
+  color: #ff8c00;
+}
+
+/* Section content */
+.privacy-section-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+  padding: 0 20px;
+}
+
+.privacy-section-content.open {
+  max-height: 500px;
+  padding: 0 20px 20px 20px;
+}
+
+.privacy-section-content p {
   line-height: 1.6;
-  margin-bottom: 10px;
+  margin: 0;
 }
 
 /* Privacy link styling */
@@ -119,12 +187,20 @@
     padding: 20px 10px;
   }
   
-  .privacy-section {
+  .privacy-section-header {
     padding: 15px;
   }
   
-  .privacy-section h2 {
+  .privacy-section-header h2 {
     font-size: 1.3rem;
+  }
+  
+  .privacy-section-content.open {
+    padding: 0 15px 15px 15px;
+  }
+  
+  .dropdown-toggle {
+    padding: 6px;
   }
 }
 
@@ -133,7 +209,23 @@
     font-size: 2rem;
   }
   
-  .privacy-section {
-    padding: 10px;
+  .privacy-section-header {
+    padding: 12px;
+  }
+  
+  .privacy-section-header h2 {
+    font-size: 1.1rem;
+  }
+  
+  .privacy-section-content.open {
+    padding: 0 12px 12px 12px;
+  }
+  
+  .dropdown-icon {
+    font-size: 0.7rem;
+  }
+  
+  .dropdown-toggle {
+    padding: 4px;
   }
 }

--- a/frontend/src/components/Privacy/privacy.jsx
+++ b/frontend/src/components/Privacy/privacy.jsx
@@ -1,9 +1,17 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import "./privacy.css";
 import { ThemeContext } from "../context/ThemeContext";
 
 const Privacy = () => {
   const { theme } = useContext(ThemeContext);
+  const [openSections, setOpenSections] = useState({});
+
+  const toggleSection = (index) => {
+    setOpenSections((prev) => ({
+      ...prev,
+      [index]: !prev[index],
+    }));
+  };
 
   return (
     <div className={`privacy-container ${theme === "dark" ? "dark" : "light"}`}>
@@ -12,56 +20,180 @@ const Privacy = () => {
         <p className="privacy-updated">Last updated: September 2025</p>
 
         <section className="privacy-section">
-          <h2>Information We Collect</h2>
-          <p>
-            We collect information you provide directly to us, such as when you create an account, 
-            place an order, or contact us for support. This may include your name, email address, 
-            phone number, delivery address, and payment information.
-          </p>
+          <div className="privacy-section-header">
+            <h2>Information We Collect</h2>
+            <button
+              className="dropdown-toggle"
+              onClick={() => toggleSection(0)}
+              aria-expanded={openSections[0]}
+            >
+              <span
+                className={`dropdown-icon ${openSections[0] ? "open" : ""}`}
+              >
+                ▼
+              </span>
+            </button>
+          </div>
+          <div
+            className={`privacy-section-content ${
+              openSections[0] ? "open" : ""
+            }`}
+          >
+            <p>
+              We collect information you provide directly to us, such as when
+              you create an account, place an order, or contact us for support.
+              This may include your name, email address, phone number, delivery
+              address, and payment information.
+            </p>
+          </div>
         </section>
 
         <section className="privacy-section">
-          <h2>How We Use Your Information</h2>
-          <p>
-            We use the information we collect to provide, maintain, and improve our services, 
-            process transactions, send you technical notices and support messages, and communicate 
-            with you about products, services, and promotional offers.
-          </p>
+          <div className="privacy-section-header">
+            <h2>How We Use Your Information</h2>
+            <button
+              className="dropdown-toggle"
+              onClick={() => toggleSection(1)}
+              aria-expanded={openSections[1]}
+            >
+              <span
+                className={`dropdown-icon ${openSections[1] ? "open" : ""}`}
+              >
+                ▼
+              </span>
+            </button>
+          </div>
+          <div
+            className={`privacy-section-content ${
+              openSections[1] ? "open" : ""
+            }`}
+          >
+            <p>
+              We use the information we collect to provide, maintain, and
+              improve our services, process transactions, send you technical
+              notices and support messages, and communicate with you about
+              products, services, and promotional offers.
+            </p>
+          </div>
         </section>
 
         <section className="privacy-section">
-          <h2>Information Sharing</h2>
-          <p>
-            We do not sell, trade, or otherwise transfer your personal information to third parties 
-            without your consent, except as described in this Privacy Policy. We may share your 
-            information with trusted service providers who assist us in operating our platform.
-          </p>
+          <div className="privacy-section-header">
+            <h2>Information Sharing</h2>
+            <button
+              className="dropdown-toggle"
+              onClick={() => toggleSection(2)}
+              aria-expanded={openSections[2]}
+            >
+              <span
+                className={`dropdown-icon ${openSections[2] ? "open" : ""}`}
+              >
+                ▼
+              </span>
+            </button>
+          </div>
+          <div
+            className={`privacy-section-content ${
+              openSections[2] ? "open" : ""
+            }`}
+          >
+            <p>
+              We do not sell, trade, or otherwise transfer your personal
+              information to third parties without your consent, except as
+              described in this Privacy Policy. We may share your information
+              with trusted service providers who assist us in operating our
+              platform.
+            </p>
+          </div>
         </section>
 
         <section className="privacy-section">
-          <h2>Data Security</h2>
-          <p>
-            We implement appropriate security measures to protect your personal information against 
-            unauthorized access, alteration, disclosure, or destruction. However, no method of 
-            transmission over the internet is 100% secure.
-          </p>
+          <div className="privacy-section-header">
+            <h2>Data Security</h2>
+            <button
+              className="dropdown-toggle"
+              onClick={() => toggleSection(3)}
+              aria-expanded={openSections[3]}
+            >
+              <span
+                className={`dropdown-icon ${openSections[3] ? "open" : ""}`}
+              >
+                ▼
+              </span>
+            </button>
+          </div>
+          <div
+            className={`privacy-section-content ${
+              openSections[3] ? "open" : ""
+            }`}
+          >
+            <p>
+              We implement appropriate security measures to protect your
+              personal information against unauthorized access, alteration,
+              disclosure, or destruction. However, no method of transmission
+              over the internet is 100% secure.
+            </p>
+          </div>
         </section>
 
         <section className="privacy-section">
-          <h2>Your Rights</h2>
-          <p>
-            You have the right to access, update, or delete your personal information. You may also 
-            opt out of certain communications from us. To exercise these rights, please contact us 
-            using the information provided below.
-          </p>
+          <div className="privacy-section-header">
+            <h2>Your Rights</h2>
+            <button
+              className="dropdown-toggle"
+              onClick={() => toggleSection(4)}
+              aria-expanded={openSections[4]}
+            >
+              <span
+                className={`dropdown-icon ${openSections[4] ? "open" : ""}`}
+              >
+                ▼
+              </span>
+            </button>
+          </div>
+          <div
+            className={`privacy-section-content ${
+              openSections[4] ? "open" : ""
+            }`}
+          >
+            <p>
+              You have the right to access, update, or delete your personal
+              information. You may also opt out of certain communications from
+              us. To exercise these rights, please contact us using the
+              information provided below.
+            </p>
+          </div>
         </section>
 
         <section className="privacy-section">
-          <h2>Contact Us</h2>
-          <p>
-            If you have any questions about this Privacy Policy, please contact us at 
-            <a href="mailto:privacy@foodie.com" className="privacy-link"> privacy@foodie.com</a>
-          </p>
+          <div className="privacy-section-header">
+            <h2>Contact Us</h2>
+            <button
+              className="dropdown-toggle"
+              onClick={() => toggleSection(5)}
+              aria-expanded={openSections[5]}
+            >
+              <span
+                className={`dropdown-icon ${openSections[5] ? "open" : ""}`}
+              >
+                ▼
+              </span>
+            </button>
+          </div>
+          <div
+            className={`privacy-section-content ${
+              openSections[5] ? "open" : ""
+            }`}
+          >
+            <p>
+              If you have any questions about this Privacy Policy, please
+              contact us at
+              <a href="mailto:privacy@foodie.com" className="privacy-link">
+                {" "}
+                privacy@foodie.com
+              </a>
+            </p>
+          </div>
         </section>
       </div>
     </div>


### PR DESCRIPTION
📌 Pull Request Summary
Added a dropdown toggle feature for each heading on the Privacy Page to improve user navigation and readability.
Now users can expand or collapse sections to view detailed content easily.

🛠️ Type of Change
 🚀 Performance improvement

🔗 Related Issue
Closes #804

✅ Checklist
 I have tested my changes locally
 I have run npm run dev to verify code behavior
 I have updated documentation (if necessary)
 My code follows the project’s coding conventions
 I have merged the latest main branch
 I have performed a self-review of my own code
 My changes generate no new warnings or errors
 I have commented my code where necessary
 I have linked the related issue

📸 Screenshots
<img width="1422" height="626" alt="image" src="https://github.com/user-attachments/assets/23b9a67d-9c91-4b08-891c-5e3ef79f02f2" />
