### PR TITLE
fix: move key prop to outermost element in ExploreMenu list to resolve missing key warning (#817)

### DIFF
--- a/frontend/src/components/ExploreMenu/ExploreMenu.jsx
+++ b/frontend/src/components/ExploreMenu/ExploreMenu.jsx
@@ -194,14 +194,13 @@ const ExploreMenu = ({ category, setCategory }) => {
         >
           {/* Triple the items for seamless infinite scroll */}
           {[...menu_list, ...menu_list, ...menu_list].map((item, index) => (
-            <a href="#food-display">  
+            <a href="#food-display" key={`${item.menu_name}-${index}`}>  
               <div
                 onClick={() =>                                                                
                   setCategory(
                     category === item.menu_name ? "All" : item.menu_name
                   )
                 }
-                key={`${item.menu_name}-${index}`}
                 className="explore-menu-list-item"
               >
                 <img


### PR DESCRIPTION
Closes #817